### PR TITLE
- adding bonzai-vault-operator

### DIFF
--- a/provisioning/kubernetes/bonzai-vault-operator/vault-operator.tf
+++ b/provisioning/kubernetes/bonzai-vault-operator/vault-operator.tf
@@ -1,0 +1,23 @@
+resource "helm_release" "vault-operator" {
+  name             = "vault-operator-${var.app_namespace}-${var.tfenv}"
+  repository       = "https://kubernetes-charts.banzaicloud.com"
+  chart            = "vault-operator"
+  namespace        = "hashicorp"
+  create_namespace = false
+  values = [<<EOT
+${local.nodeSelector}
+${local.tolerations}
+replicaCount: 2
+EOT
+  ]
+}
+
+locals {
+  nodeSelector = var.vault_nodeselector != "" ? format("nodeSelector:\n  %s", var.vault_nodeselector) : ""
+  tolerations = var.vault_tolerations != "" ? format("tolerations: \n- \"key\": \"%s\"\n  \"operator\": \"Equal\"\n  \"value\": \"%s\"\n  \"effect\": \"%s\"", split(":", var.vault_tolerations)[1], split(":", var.vault_tolerations)[2], split(":", var.vault_tolerations)[0]) : ""
+}
+
+variable "app_namespace" {}
+variable "tfenv" {}
+variable "vault_nodeselector" {}
+variable "vault_tolerations" {}

--- a/provisioning/kubernetes/bonzai-vault-secrets-webhook/vault-secrets-webhook.tf
+++ b/provisioning/kubernetes/bonzai-vault-secrets-webhook/vault-secrets-webhook.tf
@@ -1,0 +1,23 @@
+resource "helm_release" "vault-secrets-webhook" {
+  name             = "vault-secrets-webhook-${var.app_namespace}-${var.tfenv}"
+  repository       = "https://kubernetes-charts.banzaicloud.com"
+  chart            = "vault-secrets-webhook"
+  namespace        = "hashicorp"
+  create_namespace = false
+  values = [<<EOT
+${local.nodeSelector}
+${local.tolerations}
+replicaCount: 2
+EOT
+  ]
+}
+
+locals {
+  nodeSelector = var.vault_nodeselector != "" ? format("nodeSelector:\n  %s", var.vault_nodeselector) : ""
+  tolerations = var.vault_tolerations != "" ? format("tolerations: \n- \"key\": \"%s\"\n  \"operator\": \"Equal\"\n  \"value\": \"%s\"\n  \"effect\": \"%s\"", split(":", var.vault_tolerations)[1], split(":", var.vault_tolerations)[2], split(":", var.vault_tolerations)[0]) : ""
+}
+
+variable "app_namespace" {}
+variable "tfenv" {}
+variable "vault_nodeselector" {}
+variable "vault_tolerations" {}

--- a/provisioning/kubernetes/certmanager/certmanager.tf
+++ b/provisioning/kubernetes/certmanager/certmanager.tf
@@ -11,3 +11,34 @@ resource "helm_release" "certmanager" {
     value = true
   }
 }
+
+# this might be done in a nicer way tho
+resource "kubernetes_manifest" "clusterissuer_letsencrypt_prod" {
+  manifest = {
+    "apiVersion" = "cert-manager.io/v1"
+    "kind" = "ClusterIssuer"
+    "metadata" = {
+      "name" = "letsencrypt-prod"
+    }
+    "spec" = {
+      "acme" = {
+        "email" = var.letsencrypt_email
+        "privateKeySecretRef" = {
+          "name" = "letsencrypt-prod"
+        }
+        "server" = "https://acme-v02.api.letsencrypt.org/directory"
+        "solvers" = [
+          {
+            "http01" = {
+              "ingress" = {
+                "class" = "nginx"
+              }
+            }
+          },
+        ]
+      }
+    }
+  }
+}
+
+variable "letsencrypt_email" {}

--- a/provisioning/kubernetes/cluster-autoscaler/cluster-autoscaler.tf
+++ b/provisioning/kubernetes/cluster-autoscaler/cluster-autoscaler.tf
@@ -19,6 +19,12 @@ resource "helm_release" "aws-cluster-autoscaler" {
     "autoDiscovery" = {
       clusterName : "${var.app_name}-${var.app_namespace}-${var.tfenv}",
       enabled : true
+    },
+    "extraArgs" = {
+      "scale-down-utilization-threshold" : var.scale_down_util_threshold,
+      "skip-nodes-with-local-storage" : var.skip_nodes_with_local_storage,
+      "skip-nodes-with-system-pods" : var.skip_nodes_with_system_pods,
+      "cordon-node-before-terminating"  : var.cordon_node_before_term,
     }
     })
   ]

--- a/provisioning/kubernetes/cluster-autoscaler/variables.tf
+++ b/provisioning/kubernetes/cluster-autoscaler/variables.tf
@@ -3,3 +3,7 @@ variable "app_namespace" {}
 variable "tfenv" {}
 variable "cluster_oidc_issuer_url" {}
 variable "aws_region" {}
+variable "scale_down_util_threshold" {}
+variable "skip_nodes_with_local_storage" {}
+variable "skip_nodes_with_system_pods" {}
+variable "cordon_node_before_term" {}

--- a/provisioning/kubernetes/elastic-stack/README.md
+++ b/provisioning/kubernetes/elastic-stack/README.md
@@ -29,11 +29,11 @@ You can acces kibana by port forwarding to 5601
 
 #Kibana Authentication
 
-Kibana will pull logs from all the pods which means it stores sensitive information. This means we need to protect our Kibana and we need to force a login for users who visit the dashboard. We can port forward kibana on our localhost but it has no authentication option. We can use external authentication using OAuth from our Magnetic Asia's google accounts.
+Kibana will pull logs from all the pods which means it stores sensitive information. This means we need to protect our Kibana and we need to force a login for users who visit the dashboard. We can port forward kibana on our localhost but it has no authentication option. We can use external authentication using OAuth from our google accounts.
 
-First thing is to create a google auth by logging in at https://console.developers.google.com/apis/credentials?pli=1 using the cloudshareadmin@magneticasia.com.
+First thing is to create a google auth by logging in at https://console.developers.google.com/apis/credentials?pli=1 using the cloudshareadmin@mydomain.com.
 
-Create an Oauth2 Client ID. Application Type is Web Application. Make sure you authorize the domain you will use on the origin and redirect uri will be "https://yourdomain.totalticketing.com/oauth2/callback"
+Create an Oauth2 Client ID. Application Type is Web Application. Make sure you authorize the domain you will use on the origin and redirect uri will be "https://yourdomain.mydomain.com/oauth2/callback"
 
 
 Save the "Google Client ID" and "Google Client Secret" and save the values at provisioning/kubernetes/elastic-stack/src/kibana-oauth-values.yaml
@@ -47,16 +47,16 @@ This will there will be an oauth2 pod and service running on port 80
 Next is we need the ingress for kibana for this example, modify kibana-ingress.yaml to your preference. Change the domain values of these lines:
 
 ```
-    nginx.ingress.kubernetes.io/auth-signin: https://yourdomain.totalticketing.com/oauth2/start?rd=$escaped_request_uri
-    nginx.ingress.kubernetes.io/auth-url: https://yourdomain.totalticketing.com/oauth2/auth
+    nginx.ingress.kubernetes.io/auth-signin: https://yourdomain.mydomain.com/oauth2/start?rd=$escaped_request_uri
+    nginx.ingress.kubernetes.io/auth-url: https://yourdomain.mydomain.com/oauth2/auth
 ...
 spec:
   tls:
   - hosts:
-    - yourdomain.totalticketing.com
+    - yourdomain.mydomain.com
     secretName: kibana-tls-secret
   rules:
-    - host: yourdomain.totalticketing.com
+    - host: yourdomain.mydomain.com
 ```
 
 You can then apply to create the ingress:
@@ -69,16 +69,16 @@ Next is to create the oauth ingress. Modify kibana-oauth-ingress.yaml and change
 ```
 spec:
   rules:
-  - host: yourdomain.totalticketing.com
+  - host: yourdomain.mydomain.com
     http:
 ...
   tls:
   - hosts:
-    - yourdomain.totalticketing.com
+    - yourdomain.mydomain.com
     secretName:  oauth2-noc-tls
 ```
 
-yourdomain.totalticketing.com/oauth2 will then be pointed to the oauth2-proxy so that you can perform oauth.
+yourdomain.mydomain.com/oauth2 will then be pointed to the oauth2-proxy so that you can perform oauth.
 
 Apply by: 
 

--- a/provisioning/kubernetes/elastic-stack/elasticstack-logstash.tf
+++ b/provisioning/kubernetes/elastic-stack/elasticstack-logstash.tf
@@ -55,7 +55,7 @@ locals {
     s3 {
       access_key_id => ${module.iam_user.this_iam_access_key_id}
       secret_access_key => "${module.iam_user.this_iam_access_key_secret}"
-      endpoint => "https://s3.ap-southeast-1.amazonaws.com"
+      endpoint => "https://s3.${var.aws_region}.amazonaws.com"
       region => "${var.aws_region}"
       bucket => "${var.app_name}-${var.app_namespace}-${var.tfenv}-elasticstack-logs"
       additional_settings => {

--- a/provisioning/kubernetes/grafana/README.md
+++ b/provisioning/kubernetes/grafana/README.md
@@ -25,7 +25,7 @@ ingress:
   path: /
   hosts:
     #- chart-example.local
-    - <domainyouwant>.totalticketing.com
+    - <domainyouwant>.mydomain.com
   ## Extra paths to prepend to every host configuration. This is useful when working with annotation based services.
   extraPaths: []
   # - path: /*
@@ -35,7 +35,7 @@ ingress:
   tls: #[]
    - secretName: chart-ets-shared-uat1-tls
      hosts:
-       - <domainyouwant>.totalticketing.com
+       - <domainyouwant>.mydomain.com
 ```
 
 For Datasources:
@@ -55,7 +55,7 @@ For oauth configuration:
 
 ```
   server:
-    root_url: https://grafana.<cluster>.tech.totalticketing.com
+    root_url: https://grafana.<cluster>.tech.mydomain.com
 # This is for gitlab authentication    
 #  auth.gitlab:
 #    enabled: true
@@ -76,7 +76,7 @@ For oauth configuration:
     auth_url: https://accounts.google.com/o/oauth2/auth
     token_url: https://accounts.google.com/o/oauth2/token
     api_url: https://www.googleapis.com/oauth2/v1/userinfo
-    allowed_domains: magneticasia.com #email address to whitelist
+    allowed_domains: mydomain.com #email address to whitelist
 ```
 
 Then install grafana using helm by:

--- a/provisioning/kubernetes/grafana/grafana.tf
+++ b/provisioning/kubernetes/grafana/grafana.tf
@@ -42,8 +42,8 @@ grafana.ini:
     client_id: ${var.google_clientID}
     client_secret: ${var.google_clientSecret}
     scopes: "https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/userinfo.email"
-    token_url: "https://kibana.${var.app_namespace}-${var.tfenv}.${var.root_domain_name}/oauth2/token"
-    auth_url: "https://kibana.${var.app_namespace}-${var.tfenv}.${var.root_domain_name}/oauth2/auth"
+    token_url: "https://accounts.google.com/o/oauth2/token"
+    auth_url: "https://accounts.google.com/o/oauth2/auth"
     api_url: "https://www.googleapis.com/oauth2/v1/userinfo"
     allowed_domains: "${var.google_authDomain}"
 dashboardProviders:

--- a/provisioning/kubernetes/hashicorp-consul/consul.tf
+++ b/provisioning/kubernetes/hashicorp-consul/consul.tf
@@ -10,27 +10,44 @@ global:
   domain: consul.${var.app_namespace}-${var.tfenv}.${var.root_domain_name}
   datacenter: ${var.app_name}-${var.app_namespace}-${var.tfenv}
 server:
+  ${local.nodeSelector}
+  ${local.tolerations}
   enabled: true
   replicas: 2
   storageClass: gp3
 client:
+  ${local.nodeSelector}
+  ${local.tolerations}
   enabled: true
 ui:
+  ${local.nodeSelector}
+  ${local.tolerations}
   enabled: true
 syncCatalog:
   enabled: false
   toConsul: false
   toK8s: false
 connectInject:
+  ${local.nodeSelector}
+  ${local.tolerations}
   enabled: false
   default: true
 controller:
+  ${local.nodeSelector}
+  ${local.tolerations}
   enabled: true
 EOF
   ]
+}
+
+locals {
+  nodeSelector = var.vault_nodeselector != "" ? format("nodeSelector: |\n    %s", var.vault_nodeselector) : ""
+  tolerations = var.vault_tolerations != "" ? format("tolerations: |\n    - \"key\": \"%s\"\n      \"operator\": \"Equal\"\n      \"value\": \"%s\"\n      \"effect\": \"%s\"", split(":", var.vault_tolerations)[1], split(":", var.vault_tolerations)[2], split(":", var.vault_tolerations)[0]) : ""
 }
 
 variable "app_namespace" {}
 variable "tfenv" {}
 variable "root_domain_name" {}
 variable "app_name" {}
+variable "vault_nodeselector" {}
+variable "vault_tolerations" {}

--- a/provisioning/kubernetes/hashicorp-vault/vault.tf
+++ b/provisioning/kubernetes/hashicorp-vault/vault.tf
@@ -8,8 +8,12 @@ resource "helm_release" "vault" {
   values = [<<EOT
 metrics:
   enabled: true
+client:
+  ${local.nodeSelector}
+  ${local.tolerations}
 server:
   ${local.nodeSelector}
+  ${local.tolerations}
   extraSecretEnvironmentVars: 
   ${local.extraSecretEnvironmentVars}
   ingress:
@@ -31,6 +35,7 @@ EOT
 
 locals {
   nodeSelector = var.vault_nodeselector != "" ? format("nodeSelector: |\n    %s", var.vault_nodeselector) : ""
+  tolerations = var.vault_tolerations != "" ? format("tolerations: \n  - \"key\": \"%s\"\n    \"operator\": \"Equal\"\n    \"value\": \"%s\"\n    \"effect\": \"%s\"", split(":", var.vault_tolerations)[1], split(":", var.vault_tolerations)[2], split(":", var.vault_tolerations)[0]) : ""
   ## False positive regarding exposing secrets via local values in terraform; no secrets are exposed as they are managed via k8s secrets
   #tfsec:ignore:GEN002 
   extraSecretEnvironmentVars = var.enable_aws_vault_unseal ? indent(2, yamlencode([
@@ -101,5 +106,6 @@ variable "app_name" {}
 variable "enable_aws_vault_unseal" {}
 variable "billingcustomer" {}
 variable "vault_nodeselector" {}
+variable "vault_tolerations" {}
 
 # ha: $${var.enable_aws_vault_unseal ? local.haConfig_KMS : local.haConfig_default}

--- a/variables.tf
+++ b/variables.tf
@@ -236,6 +236,12 @@ variable "cluster_endpoint_public_access_cidrs" {
 }
 
 variable "vault_nodeselector" {
+  description = "for placing node/consul on specific nodes, example usage, string:'eks.amazonaws.com/nodegroup: vaultconsul_group'"
+  default = ""
+}
+
+variable "vault_tolerations" {
+  description = "for tolerating certain taint on nodes, example usage, string:'NoExecute:we_love_hashicorp:true'"
   default = ""
 }
 
@@ -256,3 +262,29 @@ variable "gitlab_kubernetes_agent_config" {
     gitlab_agent_secret = ""
   }
 }
+
+variable "letsencrypt_email" {
+ description = "email used for the clusterissuer email definition (spec.acme.email)"
+}
+
+### AWS Cluster Autoscaling 
+variable "aws_autoscaler_scale_down_util_threshold" {
+  description = "AWS Autoscaling, scale_down_util_threshold (AWS defaults to 0.5, but raising that to 0.7 to be a tad more aggressive with scaling back)"
+  default     =  0.7
+}
+
+variable "aws_autoscaler_skip_nodes_with_local_storage" {
+  description = "AWS Autoscaling, skip_nodes_with_local_storage (AWS defaults to true, also modifying to false for more scaling back)"
+  default     =  "false"
+}
+
+variable "aws_autoscaler_skip_nodes_with_system_pods" {
+  description = "AWS Autoscaling, skip_nodes_with_system_pods (AWS defaults to true, but here default to false, again to be a little bit more aggressive with scaling back)"
+  default     =  "false"
+}
+
+variable "aws_autoscaler_cordon_node_before_term" {
+  description = "AWS Autoscaling, cordon_node_before_term (AWS defaults to false, but setting it to true migth give a more friendly removal process)"
+  default     = "true"
+}
+


### PR DESCRIPTION
- adding bonzai-vault-secrets-webhook
- adding clusterissuer for letsencrypt (provisioning/kubernetes/certmanager/certmanager.tf)
  - adds `required` variable for letsencrypt_email
- adding more options to autoscaler (threshold, cordon before terminate, and include all nodes (with system pods and local storage)
  - default should be a bit more aggressive (util-threshold up from 0.5 to 0.7, and includes all nodes, but will cordon before terminate)
- adjust grafana oauth  (token_url/auth_url)
- add nodeselectors/tolerations option to consul/vault components
- adjust readme's to be a bit more generic