### PR TITLE
fix: Disable OpenTofu experiment

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,6 +1,5 @@
 terraform {
   required_version = ">= 1.1"
-  experiments      = [module_variable_optional_attrs]
 
   required_providers {
     aws = {


### PR DESCRIPTION
```
- vault.iam_user in .terraform/modules/vault.iam_user/modules/iam-user ╷
│ Error: Experiment has concluded
│ 
│   on versions.tf line 3, in terraform:
│    3:   experiments      = [module_variable_optional_attrs]
│ 
│ Experiment "module_variable_optional_attrs" is no longer available. The
│ final feature corresponding to this experiment differs from the
│ experimental form and is available in the OpenTofu language from OpenTofu
│ v1.3.0 onwards.
```